### PR TITLE
merge channel goroutine using buffered channel 

### DIFF
--- a/27-merging-chans/main.go
+++ b/27-merging-chans/main.go
@@ -114,3 +114,24 @@ func mergeTwo(a, b <-chan int) <-chan int {
 	}()
 	return c
 }
+
+func mergeBufferedChan(chans ...<-chan int) <-chan int {
+	out := make(chan int, len(chans))
+	go func() {
+		var wg sync.WaitGroup
+		wg.Add(len(chans))
+
+		for _, c := range chans {
+			go func(c <-chan int) {
+				for v := range c {
+					out <- v
+				}
+				wg.Done()
+			}(c)
+		}
+
+		wg.Wait()
+		close(out)
+	}()
+	return out
+}

--- a/27-merging-chans/main_test.go
+++ b/27-merging-chans/main_test.go
@@ -12,6 +12,7 @@ var funcs = []struct {
 	{"goroutines", merge},
 	{"reflection", mergeReflect},
 	{"recursion", mergeRec},
+	{"goroutinesBufferedChan", mergeBufferedChan},
 }
 
 func TestMerge(t *testing.T) {


### PR DESCRIPTION
One of the method to merge channel is using goroutine. I added one more method of merging channel by using buffered channel and it is faster than unbuffered channel approach