### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,11 @@
+test_task:
+  container:
+    matrix:
+      image: golang:1.9
+      image: golang:1.10
+      image: golang:1.11-rc
+  env:
+    CIRRUS_WORKING_DIR: /go/src/github.com/campoy/justforfunc
+    GO111MODULE: on
+  get_script: go get -t -v ./...
+  test_script: go test ./...


### PR DESCRIPTION
I saw on Twitter there were issues with gimme, Cirrus CI uses official `golang` Docker images which makes it independent from gimme and makes the CI builds to start in seconds.

Plus Cirrus CI is running on Google Cloud (GKE) which makes it twice as faster as the current CI by simply having faster vCPUs and Network. ⚡️⚡️

![image](https://user-images.githubusercontent.com/989066/44098166-75f57d3a-9fad-11e8-8182-8e8f5de42448.png)

![image](https://user-images.githubusercontent.com/989066/44098182-7cb4641a-9fad-11e8-95f6-545c6ff75e22.png)

Also Cirrus CI is using source{d}'s awesome `go-git` for cloning inside of a container 😉

In case you'll decide to merge, don't forget to [install Cirrus CI from GitHub Marketplace](https://github.com/marketplace/cirrus-ci) first. Or feel free to close the PR otherwise.

