### PR TITLE
fix 10 step output

### DIFF
--- a/38-linreg-vanilla/linreg/linreg.go
+++ b/38-linreg-vanilla/linreg/linreg.go
@@ -7,11 +7,11 @@ import "fmt"
 // LinearRegression runs the requested number of iterations of gradient
 // descent and returns the latest approximated coefficients.
 func LinearRegression(xs, ys []float64, iterations int, alpha float64) (m, c float64) {
-	for i := 0; i < iterations; i++ {
+	for i := 1; i < iterations+1; i++ {
 		cost, dm, dc := Gradient(xs, ys, m, c)
 		m += -dm * alpha
 		c += -dc * alpha
-		if (10 * i % iterations) == 0 {
+		if i%(iterations/10) == 0 {
 			fmt.Printf("cost(%.2f, %.2f) = %.2f\n", m, c, cost)
 		}
 	}


### PR DESCRIPTION
This change fixes the 10 step output introduced in episode 39 to 38-linreg-vanilla/linreg/linreg.go. The previous implementation was only ok for large numbers and multiples of 10, for example `go run main.go -n 1001` would only output one line. The new implementation works for numbers greater than 99 and is not terribly wrong for less than 100 iterations:

```
iterations   steps      i
11		11	[1 2 3 4 5 6 7 8 9 10 11]
12		12	[1 2 3 4 5 6 7 8 9 10 11 12]
13		13	[1 2 3 4 5 6 7 8 9 10 11 12 13]
14		14	[1 2 3 4 5 6 7 8 9 10 11 12 13 14]
15		15	[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
16		16	[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]
17		17	[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17]
18		18	[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18]
19		19	[1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19]
22		11	[2 4 6 8 10 12 14 16 18 20 22]
23		11	[2 4 6 8 10 12 14 16 18 20 22]
24		12	[2 4 6 8 10 12 14 16 18 20 22 24]
25		12	[2 4 6 8 10 12 14 16 18 20 22 24]
26		13	[2 4 6 8 10 12 14 16 18 20 22 24 26]
27		13	[2 4 6 8 10 12 14 16 18 20 22 24 26]
28		14	[2 4 6 8 10 12 14 16 18 20 22 24 26 28]
29		14	[2 4 6 8 10 12 14 16 18 20 22 24 26 28]
33		11	[3 6 9 12 15 18 21 24 27 30 33]
34		11	[3 6 9 12 15 18 21 24 27 30 33]
35		11	[3 6 9 12 15 18 21 24 27 30 33]
36		12	[3 6 9 12 15 18 21 24 27 30 33 36]
37		12	[3 6 9 12 15 18 21 24 27 30 33 36]
38		12	[3 6 9 12 15 18 21 24 27 30 33 36]
39		13	[3 6 9 12 15 18 21 24 27 30 33 36 39]
44		11	[4 8 12 16 20 24 28 32 36 40 44]
45		11	[4 8 12 16 20 24 28 32 36 40 44]
46		11	[4 8 12 16 20 24 28 32 36 40 44]
47		11	[4 8 12 16 20 24 28 32 36 40 44]
48		12	[4 8 12 16 20 24 28 32 36 40 44 48]
49		12	[4 8 12 16 20 24 28 32 36 40 44 48]
55		11	[5 10 15 20 25 30 35 40 45 50 55]
56		11	[5 10 15 20 25 30 35 40 45 50 55]
57		11	[5 10 15 20 25 30 35 40 45 50 55]
58		11	[5 10 15 20 25 30 35 40 45 50 55]
59		11	[5 10 15 20 25 30 35 40 45 50 55]
66		11	[6 12 18 24 30 36 42 48 54 60 66]
67		11	[6 12 18 24 30 36 42 48 54 60 66]
68		11	[6 12 18 24 30 36 42 48 54 60 66]
69		11	[6 12 18 24 30 36 42 48 54 60 66]
77		11	[7 14 21 28 35 42 49 56 63 70 77]
78		11	[7 14 21 28 35 42 49 56 63 70 77]
79		11	[7 14 21 28 35 42 49 56 63 70 77]
88		11	[8 16 24 32 40 48 56 64 72 80 88]
89		11	[8 16 24 32 40 48 56 64 72 80 88]
99		11	[9 18 27 36 45 54 63 72 81 90 99]
```