### PR TITLE
40-csvql: Setting column Source to be the table name

### DIFF
--- a/40-csvql/csvql.go
+++ b/40-csvql/csvql.go
@@ -60,17 +60,18 @@ func newTable(path string) (sql.Table, error) {
 		return nil, errors.Wrapf(err, "could not read headers in %s", path)
 	}
 
+	tableName := strings.TrimSuffix(filepath.Base(path), ".csv")
+
 	var schema []*sql.Column
 	for _, header := range headers {
 		schema = append(schema, &sql.Column{
 			Name:   header,
 			Type:   sql.Text,
-			Source: path,
+			Source: tableName,
 		})
 	}
 
-	name := strings.TrimSuffix(filepath.Base(path), ".csv")
-	return &table{name: name, schema: schema, path: path}, nil
+	return &table{name: tableName, schema: schema, path: path}, nil
 }
 
 func (t *table) Name() string       { return t.name }


### PR DESCRIPTION
Just a small issue.

With the code in the video, if you try and apply a projection to a query, you get this error

```
mysql> select name from cities;
ERROR 1105 (HY000): unknown error: table "cities" does not have column "name"
```

This is because the `Source` attribute in the `Column` was being set as the path of the CSV file, rather than the table name.

This PR fixes issue #93 

```
mysql> select name, country from cities where country <> 'USA';
+-----------+---------+
| name      | country |
+-----------+---------+
| Barcelona | Spain   |
| Paris     | France  |
| Shanghai  | China   |
+-----------+---------+
3 rows in set (0.00 sec)
``` 