### PR TITLE
12-say-grpc - "no such file or directory"

### DIFF
--- a/12-say-grpc/backend/Makefile
+++ b/12-say-grpc/backend/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 build:
-	GOOS=linux go build -o app
+	GOOS=linux go build -a -tags netgo -ldflags '-w' -o app
 	docker build -t gcr.io/justforfunc-prep/say .
 	rm -f app
 


### PR DESCRIPTION
example fails, I think because net requires libc which is not in alpine

https://stackoverflow.com/questions/52640304/standard-init-linux-go190-exec-user-process-caused-no-such-file-or-directory