### PR TITLE
Disable cgo explicitly for go build

### DIFF
--- a/12-say-grpc/backend/Makefile
+++ b/12-say-grpc/backend/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 build:
-	CGO_ENABLED=0 GOOS=linux go build -o app
+	CGO_ENABLED=0 GOOS=linux go build -a -o app
 	docker build -t gcr.io/justforfunc-prep/say .
 	rm -f app
 

--- a/12-say-grpc/backend/Makefile
+++ b/12-say-grpc/backend/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 build:
-	GOOS=linux go build -o app
+	CGO_ENABLED=0 GOOS=linux go build -o app
 	docker build -t gcr.io/justforfunc-prep/say .
 	rm -f app
 


### PR DESCRIPTION
Build the binary statically to avoid errors with libraries